### PR TITLE
Updated automated Docker environment.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,4 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-* @bobstrecansky @beniamin @morrisonlevi @Wizofgoz @hellofresh
+* @bobstrecansky @beniamin @morrisonlevi @zsistla @fahmy-mohammed

--- a/Context/ContextValueTrait.php
+++ b/Context/ContextValueTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Context;
+
+trait ContextValueTrait
+{
+    /**
+     * @param Context $context
+     * @return mixed|null
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
+     */
+    public static function extract(Context $context)
+    {
+        try {
+            return $context->get(static::getContextKey());
+        } catch (ContextValueNotFoundException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param mixed $value
+     * @param Context $context
+     * @return Context
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
+     */
+    public static function insert($value, Context $context): Context
+    {
+        return $context->set(static::getContextKey(), $value);
+    }
+
+    /**
+     * @param mixed $value
+     * @return Scope
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
+     */
+    public static function setCurrent($value): Scope
+    {
+        $context = Context::getCurrent()->set(static::getContextKey(), $value);
+
+        return new Scope(Context::attach($context));
+    }
+
+    /**
+     * @return mixed|null
+     * @phan-suppress PhanAbstractStaticMethodCallInTrait
+     */
+    public static function getCurrent()
+    {
+        try {
+            return Context::getCurrent()->get(static::getContextKey());
+        } catch (ContextValueNotFoundException $e) {
+            return null;
+        }
+    }
+
+    abstract protected static function getContextKey(): ContextKey;
+}

--- a/Context/Scope.php
+++ b/Context/Scope.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Context;
+
+class Scope
+{
+    /** @var callable Context token, result of Context::attach() */
+    private $contextToken;
+
+    public function __construct(callable $contextToken)
+    {
+        $this->contextToken = $contextToken;
+    }
+
+    public function close(): void
+    {
+        Context::detach($this->contextToken);
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ trace examples: FORCE
 	$(DC_RUN_PHP) php ./examples/AlwaysOnZipkinExample.php
 	$(DC_RUN_PHP) php ./examples/AlwaysOffTraceExample.php
 	$(DC_RUN_PHP) php ./examples/AlwaysOnJaegerExample.php
+        # The following examples do not use the DC_RUN_PHP global because they need environment variables.
+	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnNewrelicExample.php
+	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnZipkinToNewrelicExample.php
+
 metrics-prometheus-example:
 	@docker-compose -f docker-compose.prometheus.yaml up -d web
 	@docker-compose -f docker-compose.prometheus.yaml run php-prometheus php /var/www/public/examples/prometheus/PrometheusMetricsExample.php

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ trace examples: FORCE
         # The following examples do not use the DC_RUN_PHP global because they need environment variables.
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnNewrelicExample.php
 	docker-compose run -e NEW_RELIC_ENDPOINT -e NEW_RELIC_INSERT_KEY --rm php php ./examples/AlwaysOnZipkinToNewrelicExample.php
-
+collector-trace: FORCE
+	docker-compose run -e OTEL_EXPORTER_OTLP_ENDPOINT --rm php php ./examples/AlwaysOnOTLPGrpcExample.php
 metrics-prometheus-example:
 	@docker-compose -f docker-compose.prometheus.yaml up -d web
 	@docker-compose -f docker-compose.prometheus.yaml run php-prometheus php /var/www/public/examples/prometheus/PrometheusMetricsExample.php

--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ You can use the [examples/AlwaysOnZipkinExample.php](/examples/AlwaysOnZipkinExa
 
 You can also use the [examples/AlwaysOnJaegerExample.php](/examples/AlwaysOnJaegerExample.php) file to test out the reference implementation we have for jaegar.  This example perfoms a sample trace with a grouping of 5 spans and POSTs the result to a local jaegar instance.
 
-The PHP for both examples should execute by itself (if you have a zipkin or jaegar instance running on localhost), but if you'd like a no-fuss way to test this out with docker and docker-compose, you can perform the following simple steps:
+You can use the [examples/AlwaysOnZipkinToNewrelicExample.php](/examples/AlwaysOnZipkinToNewrelicExample.php) file to test out the reference implementation we have for zipkin to Newrelic.  This example perfoms a sample trace with spans and POSTs the result to a Newrelic endpoint.  This requires a license key (free accounts available) to be set in the environment (NEW_RELIC_INSERT_KEY) to authenticate to the backend.
+
+You can use the [examples/AlwaysOnNewrelicExample.php](/examples/AlwaysOnNewrelicExample.php) file to test out the reference implementation we have for Newrelic.  This example perfoms a sample trace with spans and POSTs the result to a Newrelic endpoint.  This requires a license key (free accounts available) set in the environment (NEW_RELIC_INSERT_KEY) to authenticate to the backend.
+
+The PHP for all examples should execute by itself (if you have a zipkin or jaegar instance running on localhost), but if you'd like a no-fuss way to test this out with docker and docker-compose, you can perform the following simple steps:
 
 1.)  Install the necessary dependencies by running `make install`.  This will install the composer dependencies and store them in `/vendor`  
 2.)  Execute the example trace using `make trace examples`.

--- a/api/CorrelationContext.php
+++ b/api/CorrelationContext.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace OpenTelemetry\CorrelationContext;
+namespace OpenTelemetry;
 
 use OpenTelemetry\Context\ContextKey;
 

--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Trace;
 
+use OpenTelemetry\Context\Context;
+
 interface Tracer
 {
+    public function startSpan(
+        string $name,
+        ?Context $parentContext = null,
+        int $spanKind = SpanKind::KIND_INTERNAL,
+        ?Attributes $attributes = null,
+        ?Links $links = null,
+        ?int $startTimestamp = null
+    ): Span;
+
     public function getActiveSpan(): Span;
 
     public function startAndActivateSpan(string $name, int $spanKind = SpanKind::KIND_INTERNAL): Span;

--- a/api/Trace/Tracer.php
+++ b/api/Trace/Tracer.php
@@ -8,7 +8,7 @@ interface Tracer
 {
     public function getActiveSpan(): Span;
 
-    public function startAndActivateSpan(string $name): Span;
+    public function startAndActivateSpan(string $name, int $spanKind = SpanKind::KIND_INTERNAL): Span;
     public function startSpanWithOptions(string $name): SpanOptions;
 
     public function setActiveSpan(Span $span): void;

--- a/contrib/Newrelic/Exporter.php
+++ b/contrib/Newrelic/Exporter.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Newrelic;
+
+use GuzzleHttp\Psr7\Request;
+use Http\Adapter\Guzzle7\Client;
+use InvalidArgumentException;
+use OpenTelemetry\Sdk\Trace;
+use OpenTelemetry\Trace as API;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * Class NewrelicExporter - implements the export interface for data transfer via Newrelic protocol
+ * @package OpenTelemetry\Exporter
+ *
+ * This is an experimental, non-supported exporter.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+class Exporter implements Trace\Exporter
+{
+    private const DATA_FORMAT = 'newrelic';
+    private const DATA_FORMAT_VERSION_DEFAULT = '1';
+
+    /**
+     * @var string
+     */
+    private $endpointUrl;
+
+    /**
+     * @var string
+     */
+    private $licenseKey;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var SpanConverter
+     */
+    private $spanConverter;
+
+    /**
+     * @var bool
+     */
+    private $running = true;
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    private $dataFormatVersion;
+
+    public function __construct(
+        $name,
+        string $endpointUrl,
+        string $licenseKey,
+        SpanConverter $spanConverter = null,
+        ClientInterface $client = null,
+        string $dataFormatVersion = Exporter::DATA_FORMAT_VERSION_DEFAULT
+    ) {
+        $parsedDsn = parse_url($endpointUrl);
+
+        if (!is_array($parsedDsn)) {
+            throw new InvalidArgumentException('Unable to parse provided DSN');
+        }
+        if (
+            !isset($parsedDsn['scheme'])
+            || !isset($parsedDsn['host'])
+            || !isset($parsedDsn['path'])
+        ) {
+            throw new InvalidArgumentException('Endpoint should have scheme, host, port and path');
+        }
+        $this->dataFormatVersion = $dataFormatVersion;
+        $this->licenseKey = $licenseKey;
+        $this->endpointUrl = $endpointUrl;
+        $this->name = $name;
+        $this->client = $client ?? $this->createDefaultClient();
+        $this->spanConverter = $spanConverter ?? new SpanConverter($name);
+    }
+
+    /**
+     * Exports the provided Span data via the Newrelic protocol
+     *
+     * @param iterable<API\Span> $spans Array of Spans
+     * @return int return code, defined on the Exporter interface
+     */
+    public function export(iterable $spans): int
+    {
+        if (!$this->running) {
+            return Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if (empty($spans)) {
+            return Trace\Exporter::SUCCESS;
+        }
+
+        $convertedSpans = [];
+        foreach ($spans as $span) {
+            array_push($convertedSpans, $this->spanConverter->convert($span));
+        }
+        $commonAttributes = ['attributes' => [ 'service.name' => $this->name,
+                                               'host' => $this->endpointUrl, ]];
+        $payload = [[ 'common' => $commonAttributes,
+                     'spans' => $convertedSpans, ]];
+
+        try {
+            $json = json_encode($payload);
+            $headers = ['content-type' => 'application/json',
+                        'Api-Key' => $this->licenseKey,
+                        'Data-Format' => Exporter::DATA_FORMAT,
+                        'Data-Format-Version' => $this->dataFormatVersion, ];
+            $request = new Request('POST', $this->endpointUrl, $headers, $json);
+            $response = $this->client->sendRequest($request);
+        } catch (RequestExceptionInterface $e) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        } catch (NetworkExceptionInterface | ClientExceptionInterface $e) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        $statusCode = $response->getStatusCode();
+        $reason = $response->getReasonPhrase();
+
+        // Useful information for when logging is implemented.
+        /*
+         * echo "\nsendRequest response = " . $statusCode . "\n";
+         * echo "\nsendRequest response = " . $reason . "\n";
+         */
+        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if ($response->getStatusCode() >= 500 && $response->getStatusCode() < 600) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        return Trace\Exporter::SUCCESS;
+    }
+
+    public function shutdown(): void
+    {
+        $this->running = false;
+    }
+
+    protected function createDefaultClient(): ClientInterface
+    {
+        return Client::createWithConfig([
+            'timeout' => 30,
+        ]);
+    }
+}

--- a/contrib/Newrelic/SpanConverter.php
+++ b/contrib/Newrelic/SpanConverter.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\Newrelic;
+
+use OpenTelemetry\Trace\Span;
+
+class SpanConverter
+{
+    const STATUS_CODE_TAG_KEY = 'otel.status_code';
+    const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
+
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    public function __construct(string $serviceName)
+    {
+        $this->serviceName = $serviceName;
+    }
+
+    public function convert(Span $span)
+    {
+        $spanParent = $span->getParent();
+        $row = [
+            'id' => $span->getContext()->getSpanId(),
+            'trace.id' => $span->getContext()->getTraceId(),
+            'attributes' => [
+                'name' => $span->getSpanName(),
+                'service.name' => $this->serviceName,
+                'parent.id' => $spanParent ? $spanParent->getSpanId() : null,
+                'timestamp' => ($span->getStartEpochTimestamp()  / 1e6), // RealtimeClock in milliseconds
+                'duration.ms' => (($span->getEnd() - $span->getStart())  / 1e6), // Diff in milliseconds
+                self::STATUS_CODE_TAG_KEY => $span->getStatus()->getCanonicalStatusCode(),
+                self::STATUS_DESCRIPTION_TAG_KEY => $span->getStatus()->getStatusDescription(),
+            ],
+        ];
+
+        foreach ($span->getAttributes() as $k => $v) {
+            $row['attributes'][$k] = $v->getValue();
+        }
+
+        /*
+        foreach ($span->getEvents() as $event) {
+            if (!array_key_exists('annotations', $row)) {
+                $row['annotations'] = [];
+            }
+            $row['annotations'][] = [
+                'timestamp' => (int) ($event->getTimestamp() / 1e6), // RealtimeClock in milliseconds
+                'value' => $event->getName(),
+            ];
+        }
+    */
+        return $row;
+    }
+}

--- a/contrib/Otlp/Exporter.php
+++ b/contrib/Otlp/Exporter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Otlp;
 
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use Http\Adapter\Guzzle7\Client;
 use OpenTelemetry\Sdk\Trace;
@@ -55,7 +53,7 @@ class Exporter implements Trace\Exporter
      * @var SpanConverter
      */
     private $spanConverter;
-    
+
     /**
     * @var bool
     */
@@ -100,7 +98,7 @@ class Exporter implements Trace\Exporter
         if (!$this->running) {
             return Exporter::FAILED_NOT_RETRYABLE;
         }
-        
+
         if (empty($spans)) {
             return Trace\Exporter::SUCCESS;
         }
@@ -145,14 +143,7 @@ class Exporter implements Trace\Exporter
 
     protected function createDefaultClient(): ClientInterface
     {
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create();
-        // Add the history middleware to the handler stack.
-        $stack->push($history);
-
         return Client::createWithConfig([
-            'handler' => $stack,
             'timeout' => 30,
         ]);
     }

--- a/contrib/Zipkin/Exporter.php
+++ b/contrib/Zipkin/Exporter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\Zipkin;
 
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use Http\Adapter\Guzzle7\Client;
 use InvalidArgumentException;
@@ -118,14 +116,7 @@ class Exporter implements Trace\Exporter
 
     protected function createDefaultClient(): ClientInterface
     {
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create();
-        // Add the history middleware to the handler stack.
-        $stack->push($history);
-
         return Client::createWithConfig([
-            'handler' => $stack,
             'timeout' => 30,
         ]);
     }

--- a/contrib/ZipkinToNewrelic/Exporter.php
+++ b/contrib/ZipkinToNewrelic/Exporter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Contrib\ZipkinToNewrelic;
 
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
 use Http\Adapter\Guzzle7\Client;
 use InvalidArgumentException;
@@ -135,14 +133,7 @@ class Exporter implements Trace\Exporter
 
     protected function createDefaultClient(): ClientInterface
     {
-        $container = [];
-        $history = Middleware::history($container);
-        $stack = HandlerStack::create();
-        // Add the history middleware to the handler stack.
-        $stack->push($history);
-
         return Client::createWithConfig([
-            'handler' => $stack,
             'timeout' => 30,
         ]);
     }

--- a/contrib/ZipkinToNewrelic/Exporter.php
+++ b/contrib/ZipkinToNewrelic/Exporter.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\ZipkinToNewrelic;
+
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use Http\Adapter\Guzzle7\Client;
+use InvalidArgumentException;
+use OpenTelemetry\Sdk\Trace;
+use OpenTelemetry\Trace as API;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+/**
+ * Class ZipkinExporter - implements the export interface for data transfer via Zipkin protocol
+ * @package OpenTelemetry\Exporter
+ *
+ * This is an experimental, non-supported exporter.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+class Exporter implements Trace\Exporter
+{
+    /**
+     * @var string
+     */
+    private $endpointUrl;
+
+    /**
+     * @var string
+     */
+    private $licenseKey;
+
+    /**
+     * @var SpanConverter
+     */
+    private $spanConverter;
+
+    /**
+     * @var bool
+     */
+    private $running = true;
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    public function __construct(
+        $name,
+        string $endpointUrl,
+        string $licenseKey,
+        SpanConverter $spanConverter = null,
+        ClientInterface $client = null
+    ) {
+        $parsedDsn = parse_url($endpointUrl);
+
+        if (!is_array($parsedDsn)) {
+            throw new InvalidArgumentException('Unable to parse provided DSN');
+        }
+        if (
+            !isset($parsedDsn['scheme'])
+            || !isset($parsedDsn['host'])
+            || !isset($parsedDsn['path'])
+        ) {
+            throw new InvalidArgumentException('Endpoint should have scheme, host, port and path');
+        }
+
+        $this->licenseKey = $licenseKey;
+        $this->endpointUrl = $endpointUrl;
+        $this->client = $client ?? $this->createDefaultClient();
+        $this->spanConverter = $spanConverter ?? new SpanConverter($name);
+    }
+
+    /**
+     * Exports the provided Span data via the Zipkin protocol
+     *
+     * @param iterable<API\Span> $spans Array of Spans
+     * @return int return code, defined on the Exporter interface
+     */
+    public function export(iterable $spans): int
+    {
+        if (!$this->running) {
+            return Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if (empty($spans)) {
+            return Trace\Exporter::SUCCESS;
+        }
+
+        $convertedSpans = [];
+        foreach ($spans as $span) {
+            array_push($convertedSpans, $this->spanConverter->convert($span));
+        }
+
+        try {
+            $json = json_encode($convertedSpans);
+            $headers = ['content-type' => 'application/json',
+                        'Api-Key' => $this->licenseKey,
+                        'Data-Format' => 'zipkin',
+                        'Data-Format-Version' => '2', ];
+            $request = new Request('POST', $this->endpointUrl, $headers, $json);
+            $response = $this->client->sendRequest($request);
+        } catch (RequestExceptionInterface $e) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        } catch (NetworkExceptionInterface | ClientExceptionInterface $e) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        $statusCode = $response->getStatusCode();
+        $reason = $response->getReasonPhrase();
+        echo "\nsendRequest response = " . $statusCode . "\n";
+        echo "\nsendRequest response = " . $reason . "\n";
+
+        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
+            return Trace\Exporter::FAILED_NOT_RETRYABLE;
+        }
+
+        if ($response->getStatusCode() >= 500 && $response->getStatusCode() < 600) {
+            return Trace\Exporter::FAILED_RETRYABLE;
+        }
+
+        return Trace\Exporter::SUCCESS;
+    }
+
+    public function shutdown(): void
+    {
+        $this->running = false;
+    }
+
+    protected function createDefaultClient(): ClientInterface
+    {
+        $container = [];
+        $history = Middleware::history($container);
+        $stack = HandlerStack::create();
+        // Add the history middleware to the handler stack.
+        $stack->push($history);
+
+        return Client::createWithConfig([
+            'handler' => $stack,
+            'timeout' => 30,
+        ]);
+    }
+}

--- a/contrib/ZipkinToNewrelic/SpanConverter.php
+++ b/contrib/ZipkinToNewrelic/SpanConverter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Contrib\ZipkinToNewrelic;
+
+use OpenTelemetry\Trace\Span;
+
+class SpanConverter
+{
+    const STATUS_CODE_TAG_KEY = 'otel.status_code';
+    const STATUS_DESCRIPTION_TAG_KEY = 'otel.status_description';
+    /**
+     * @var string
+     */
+    private $serviceName;
+
+    public function __construct(string $serviceName)
+    {
+        $this->serviceName = $serviceName;
+    }
+
+    private function sanitiseTagValue($value)
+    {
+        // Casting false to string makes an empty string
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        // Zipkin tags must be strings, but opentelemetry
+        // accepts strings, booleans, numbers, and lists of each.
+        if (is_array($value)) {
+            return join(',', array_map([$this, 'sanitiseTagValue'], $value));
+        }
+
+        // Floats will lose precision if their string representation
+        // is >=14 or >=17 digits, depending on PHP settings.
+        // Can also throw E_RECOVERABLE_ERROR if $value is an object
+        // without a __toString() method.
+        // This is possible because OpenTelemetry\Trace\Span does not verify
+        // setAttribute() $value input.
+        return (string) $value;
+    }
+
+    public function convert(Span $span)
+    {
+        $spanParent = $span->getParent();
+        $row = [
+            'id' => $span->getContext()->getSpanId(),
+            'traceId' => $span->getContext()->getTraceId(),
+            'parentId' => $spanParent ? $spanParent->getSpanId() : null,
+            'localEndpoint' => [
+                'serviceName' => $this->serviceName,
+            ],
+            'name' => $span->getSpanName(),
+            'timestamp' => (int) ($span->getStartEpochTimestamp() / 1e3), // RealtimeClock in microseconds
+            'duration' => (int) (($span->getEnd() - $span->getStart()) / 1e3), // Diff in microseconds
+            'tags' => [
+                self::STATUS_CODE_TAG_KEY => $span->getStatus()->getCanonicalStatusCode(),
+                self::STATUS_DESCRIPTION_TAG_KEY => $span->getStatus()->getStatusDescription(),
+            ],
+        ];
+
+        foreach ($span->getAttributes() as $k => $v) {
+            $row['tags'][$k] = $this->sanitiseTagValue($v->getValue());
+        }
+
+        foreach ($span->getEvents() as $event) {
+            if (!array_key_exists('annotations', $row)) {
+                $row['annotations'] = [];
+            }
+            $row['annotations'][] = [
+                'timestamp' => (int) ($event->getTimestamp() / 1e3), // RealtimeClock in microseconds
+                'value' => $event->getName(),
+            ];
+        }
+
+        return $row;
+    }
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,4 +9,9 @@ docker-php-ext-enable ast xdebug && \
 # The pcntl extension is used for speeding up `make phan`
 docker-php-ext-install pcntl
 
+# install GRPC
+RUN apt install -y --no-install-recommends zlib1g-dev && \ 
+    pecl install grpc && \
+    docker-php-ext-enable grpc
+
 WORKDIR /usr/src/myapp

--- a/examples/AlwaysOnNewrelicExample.php
+++ b/examples/AlwaysOnNewrelicExample.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Contrib\Newrelic\Exporter as NewrelicExporter;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
+
+/*
+ * Experimental example to send trace data to New Relic.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+
+$sampler = new AlwaysOnSampler();
+$samplingResult = $sampler->shouldSample(
+    null,
+    md5((string) microtime(true)),
+    substr(md5((string) microtime(true)), 16),
+    'io.opentelemetry.example',
+    API\SpanKind::KIND_INTERNAL
+);
+
+$licenseKey = getenv('NEW_RELIC_INSERT_KEY');
+
+// Needs a license key in the environment to connect to the backend server.
+
+if ($licenseKey == false) {
+    echo PHP_EOL . 'NEW_RELIC_INSERT_KEY not found in environment. Newrelic Example tracing is not enabled.';
+
+    return;
+}
+
+/*
+ * Default Trace API endpoint: https://trace-api.newrelic.com/trace/v1
+ * EU data centers: https://trace-api.eu.newrelic.com/trace/v1
+ */
+
+$endpointUrl =  getenv('NEW_RELIC_ENDPOINT');
+
+if ($endpointUrl == false) {
+    $endpointUrl = 'https://trace-api.newrelic.com/trace/v1';
+}
+
+$newrelicExporter = new NewrelicExporter(
+    'alwaysOnNewrelicExample',
+    $endpointUrl,
+    $licenseKey
+);
+
+if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+    echo 'Starting AlwaysOnNewrelicExample';
+    $tracer = (new TracerProvider())
+        ->addSpanProcessor(new SimpleSpanProcessor($newrelicExporter))
+        ->getTracer('io.opentelemetry.contrib.php');
+
+    for ($i = 0; $i < 5; $i++) {
+        // start a span, register some events
+        $timestamp = Clock::get()->timestamp();
+        $span = $tracer->startAndActivateSpan('session.generate.span.' . microtime(true));
+
+        $spanParent = $span->getParent();
+        echo sprintf(
+            PHP_EOL . 'Exporting Trace: %s, Parent: %s, Span: %s',
+            $span->getContext()->getTraceId(),
+            $spanParent ? $spanParent->getSpanId() : 'None',
+            $span->getContext()->getSpanId()
+        );
+
+        $span->setAttribute('remote_ip', '1.2.3.4')
+            ->setAttribute('country', 'USA');
+
+        $span->addEvent('found_login' . $i, $timestamp, new Attributes([
+            'id' => $i,
+            'username' => 'otuser' . $i,
+        ]));
+        $span->addEvent('generated_session', $timestamp, new Attributes([
+            'id' => md5((string) microtime(true)),
+        ]));
+
+        $tracer->endActiveSpan();
+    }
+    echo PHP_EOL . 'NewrelicExample complete!  See the results at https://one.newrelic.com/launcher/distributed-tracing.launcher?pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmhvbWUiLCJzb3J0SW5kZXgiOjAsInNvcnREaXJlY3Rpb24iOiJERVNDIiwicXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJpbmRleFF1ZXJ5Ijp7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9uU2V0cyI6W119LCJzcGFuUXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25TZXRzIjpbeyJjb25kaXRpb25UeXBlIjoiU1BBTiIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W3siYXR0ciI6InNlcnZpY2UubmFtZSIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6ImFsd2F5c09uTmV3cmVsaWNFeGFtcGxlIn1dfV19fX0=&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true';
+} else {
+    echo PHP_EOL . 'NewrelicExample tracing is not enabled';
+}
+
+echo PHP_EOL;

--- a/examples/AlwaysOnZipkinToNewrelicExample.php
+++ b/examples/AlwaysOnZipkinToNewrelicExample.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter as ZipkinToNewrelicExporter;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\SamplingResult;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
+
+/*
+ * Experimental example to send trace data to New Relic.
+ * It will send PHP Otel trace data end to end across the internet to a functional backend.
+ * Needs a license key to connect.  For a free account/key, go to: https://newrelic.com/signup/
+ */
+
+$sampler = new AlwaysOnSampler();
+$samplingResult = $sampler->shouldSample(
+    null,
+    md5((string) microtime(true)),
+    substr(md5((string) microtime(true)), 16),
+    'io.opentelemetry.example',
+    API\SpanKind::KIND_INTERNAL
+);
+
+$licenseKey = getenv('NEW_RELIC_INSERT_KEY');
+
+// Needs a license key in the environment to connect to the backend server.
+
+if ($licenseKey == false) {
+    echo PHP_EOL . 'NEW_RELIC_INSERT_KEY not found in environment. Newrelic Example tracing is not enabled.';
+
+    return;
+}
+
+/*
+ * Default Trace API endpoint: https://trace-api.newrelic.com/trace/v1
+ * EU data centers: https://trace-api.eu.newrelic.com/trace/v1
+ */
+
+$endpointUrl =  getenv('NEW_RELIC_ENDPOINT');
+
+if ($endpointUrl == false) {
+    $endpointUrl = 'https://trace-api.newrelic.com/trace/v1';
+}
+
+$zipkinToNewrelicExporter = new ZipkinToNewrelicExporter(
+    'alwaysOnZipkinToNewrelicExample',
+    $endpointUrl,
+    $licenseKey
+);
+
+if (SamplingResult::RECORD_AND_SAMPLED === $samplingResult->getDecision()) {
+    echo 'Starting AlwaysOnZipkinToNewRelicExample';
+    $tracer = (new TracerProvider())
+        ->addSpanProcessor(new SimpleSpanProcessor($zipkinToNewrelicExporter))
+        ->getTracer('io.opentelemetry.contrib.php');
+
+    for ($i = 0; $i < 5; $i++) {
+        // start a span, register some events
+        $timestamp = Clock::get()->timestamp();
+        $span = $tracer->startAndActivateSpan('session.generate.span.' . microtime(true));
+
+        $spanParent = $span->getParent();
+        echo sprintf(
+            PHP_EOL . 'Exporting Trace: %s, Parent: %s, Span: %s',
+            $span->getContext()->getTraceId(),
+            $spanParent ? $spanParent->getSpanId() : 'None',
+            $span->getContext()->getSpanId()
+        );
+
+        $span->setAttribute('remote_ip', '1.2.3.4')
+            ->setAttribute('country', 'USA');
+
+        $span->addEvent('found_login' . $i, $timestamp, new Attributes([
+            'id' => $i,
+            'username' => 'otuser' . $i,
+        ]));
+        $span->addEvent('generated_session', $timestamp, new Attributes([
+            'id' => md5((string) microtime(true)),
+        ]));
+
+        $tracer->endActiveSpan();
+    }
+    echo PHP_EOL . 'AlwaysOnZipkinToNewrelicExample complete!  See the results at https://one.newrelic.com/launcher/distributed-tracing.launcher?pane=eyJuZXJkbGV0SWQiOiJkaXN0cmlidXRlZC10cmFjaW5nLmhvbWUiLCJzb3J0SW5kZXgiOjAsInNvcnREaXJlY3Rpb24iOiJERVNDIiwicXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJpbmRleFF1ZXJ5Ijp7ImNvbmRpdGlvblR5cGUiOiJJTkRFWCIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9uU2V0cyI6W119LCJzcGFuUXVlcnkiOnsib3BlcmF0b3IiOiJBTkQiLCJjb25kaXRpb25TZXRzIjpbeyJjb25kaXRpb25UeXBlIjoiU1BBTiIsIm9wZXJhdG9yIjoiQU5EIiwiY29uZGl0aW9ucyI6W3siYXR0ciI6InNlcnZpY2UubmFtZSIsIm9wZXJhdG9yIjoiRVEiLCJ2YWx1ZSI6ImFsd2F5c09uWmlwa2luVG9OZXdyZWxpY0V4YW1wbGUifV19XX19fQ==&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=true';
+} else {
+    echo PHP_EOL . 'AlwaysOnZipkinToNewrelicExample tracing is not enabled';
+}
+
+echo PHP_EOL;

--- a/examples/ParentSpanExample.php
+++ b/examples/ParentSpanExample.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use OpenTelemetry\Contrib\Jaeger\Exporter as JaegerExporter;
+use OpenTelemetry\Contrib\Zipkin\Exporter as ZipkinExporter;
+use OpenTelemetry\Sdk\Resource\ResourceInfo;
+use OpenTelemetry\Sdk\Trace\Sampler\AlwaysOnSampler;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanProcessor\SimpleSpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+
+$serviceName = 'ParentSpanExample';
+$resource = ResourceInfo::defaultResource();
+$sampler = new AlwaysOnSampler();
+$tracerProvider = new TracerProvider($resource, $sampler);
+
+// zipkin exporter
+$zipkinExporter = new ZipkinExporter(
+    $serviceName,
+    'http://zipkin:9411/api/v2/spans'
+);
+$tracerProvider->addSpanProcessor(new SimpleSpanProcessor($zipkinExporter));
+
+// jaeger exporter
+$jaegerExporter = new JaegerExporter(
+    $serviceName,
+    'http://jaeger:9412/api/v2/spans'
+);
+$tracerProvider->addSpanProcessor(new SimpleSpanProcessor($jaegerExporter));
+
+$tracer = $tracerProvider->getTracer('example.php.opentelemetry.io', '0.0.1');
+
+$rootSpan = $tracer->startSpan('root-span');
+sleep(1);
+
+$rootScope = Span::setCurrent($rootSpan); // set the root span active in the current context
+
+try {
+    $span1 = $tracer->startSpan('child-span-1');
+    $internalScope = Span::setCurrent($span1); // set the child span active in the context
+
+    try {
+        for ($i = 0; $i < 3; $i++) {
+            $loopSpan = $tracer->startSpan('loop-' . $i);
+            usleep((int) (0.5 * 1e6));
+            $loopSpan->end();
+        }
+    } finally {
+        $internalScope->close(); // deactivate child span, the rootSpan is set back as active
+    }
+    $span1->end();
+    
+    $span2 = $tracer->startSpan('child-span-2');
+    sleep(1);
+    $span2->end();
+} finally {
+    $rootScope->close(); // close the scope of the root span, no active span in the context now
+}
+$rootSpan->end();
+ 
+// start the second root span
+$secondRootSpan = $tracer->startSpan('root-span-2');
+sleep(2);
+$secondRootSpan->end();
+
+echo 'This example generates two traces:' . PHP_EOL;
+echo '  - ' . $rootSpan->getContext()->getTraceId() . PHP_EOL;
+echo '  - ' . $secondRootSpan->getContext()->getTraceId() . PHP_EOL;
+echo PHP_EOL;
+echo 'See the results at' . PHP_EOL;
+echo 'Jaeger: http://localhost:16686/' . PHP_EOL;
+echo 'Zipkin: http://localhost:9411/' . PHP_EOL;

--- a/sdk/Trace/NoopSpan.php
+++ b/sdk/Trace/NoopSpan.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace;
 
 use Exception;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueTrait;
 use OpenTelemetry\Trace as API;
 
-class NoopSpan implements \OpenTelemetry\Trace\Span
+class NoopSpan implements API\Span
 {
+    use ContextValueTrait;
+
     /** @var API\SpanContext */
     private $context;
 
@@ -182,5 +186,14 @@ class NoopSpan implements \OpenTelemetry\Trace\Span
     public function isStatusOk(): bool
     {
         return $this->status->isStatusOK();
+    }
+
+    /**
+     * @return ContextKey
+     * @phan-override
+     */
+    protected static function getContextKey(): ContextKey
+    {
+        return SpanContextKey::instance();
     }
 }

--- a/sdk/Trace/PropagationMap.php
+++ b/sdk/Trace/PropagationMap.php
@@ -26,6 +26,10 @@ class PropagationMap implements API\PropagationGetter, API\PropagationSetter
 
             foreach ($carrier as $k => $value) {
                 if (strtolower($k) === $lKey) {
+                    if (\is_array($value)) {
+                        return empty($value) ? null : $value[0];
+                    }
+
                     return $value;
                 }
             }

--- a/sdk/Trace/Span.php
+++ b/sdk/Trace/Span.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace OpenTelemetry\Sdk\Trace;
 
 use Exception;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueTrait;
 use OpenTelemetry\Sdk\Resource\ResourceInfo;
 use OpenTelemetry\Trace as API;
 
 class Span implements API\Span
 {
+    use ContextValueTrait;
+
     private $name;
     private $spanContext;
     private $parentSpanContext;
@@ -33,6 +37,9 @@ class Span implements API\Span
 
     private $ended = false;
 
+    /** @var ?SpanProcessor */
+    private $spanProcessor;
+
     // todo: missing links: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#add-links
 
     // -> Need to understand the difference between SpanKind and links.  From the documentation:
@@ -52,7 +59,8 @@ class Span implements API\Span
         ?API\SpanContext $parentSpanContext = null,
         ?Sampler $sampler = null,
         ?ResourceInfo $resource = null,
-        int $spanKind = API\SpanKind::KIND_INTERNAL
+        int $spanKind = API\SpanKind::KIND_INTERNAL,
+        ?SpanProcessor $spanProcessor = null
     ) {
         $this->name = $name;
         $this->spanContext = $spanContext;
@@ -60,6 +68,7 @@ class Span implements API\Span
         $this->spanKind = $spanKind;
         $this->sampler = $sampler;
         $this->resource =  $resource ?? ResourceInfo::emptyResource();
+        $this->spanProcessor = $spanProcessor;
         $moment = Clock::get()->moment();
         $this->startEpochTimestamp = $moment[0];
         $this->start = $moment[1];
@@ -112,6 +121,10 @@ class Span implements API\Span
         if (!isset($this->end)) {
             $this->end = $now ?? Clock::get()->now();
             $this->ended = true;
+        }
+
+        if ($this->spanProcessor !== null) {
+            $this->spanProcessor->onEnd($this);
         }
 
         return $this;
@@ -282,5 +295,14 @@ class Span implements API\Span
     public function isStatusOk(): bool
     {
         return $this->spanStatus->isStatusOK();
+    }
+
+    /**
+     * @return ContextKey
+     * @phan-override
+     */
+    protected static function getContextKey(): ContextKey
+    {
+        return SpanContextKey::instance();
     }
 }

--- a/sdk/Trace/SpanContext.php
+++ b/sdk/Trace/SpanContext.php
@@ -74,6 +74,11 @@ final class SpanContext implements API\SpanContext
         $this->isValid = $this->traceId !== self::INVALID_TRACE && $this->spanId !== self::INVALID_SPAN;
     }
 
+    public static function getInvalid(): API\SpanContext
+    {
+        return new self(self::INVALID_TRACE, self::INVALID_SPAN, 0);
+    }
+
     /**
      * Creates a new context with random trace
      *

--- a/sdk/Trace/SpanContextKey.php
+++ b/sdk/Trace/SpanContextKey.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Sdk\Trace;
+
+use OpenTelemetry\Context\ContextKey;
+
+/**
+ * Class SpanContextKey
+ * @package OpenTelemetry\Sdk\Trace
+ * @internal
+ */
+class SpanContextKey extends ContextKey
+{
+    private const KEY_NAME = 'opentelemetry-trace-span-key';
+
+    /**
+     * @var ContextKey
+     */
+    private static $instance;
+    
+    public static function instance(): ContextKey
+    {
+        if (self::$instance === null) {
+            self::$instance = new ContextKey(self::KEY_NAME);
+        }
+        
+        return self::$instance;
+    }
+}

--- a/sdk/Trace/SpanProcessor.php
+++ b/sdk/Trace/SpanProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Trace as API;
 
 interface SpanProcessor
@@ -13,7 +14,7 @@ interface SpanProcessor
      * This method is called synchronously on the thread that started the span,
      * therefore it should not block or throw exceptions.
      */
-    public function onStart(API\Span $span): void;
+    public function onStart(API\Span $span, ?Context $parentContext = null): void;
 
     /**
      * This method  is called when a span is ended.

--- a/sdk/Trace/SpanProcessor/BatchSpanProcessor.php
+++ b/sdk/Trace/SpanProcessor/BatchSpanProcessor.php
@@ -6,6 +6,7 @@ namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
 use InvalidArgumentException;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Clock;
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
@@ -76,7 +77,7 @@ class BatchSpanProcessor implements SpanProcessor
     /**
      * @inheritDoc
      */
-    public function onStart(API\Span $span): void
+    public function onStart(API\Span $span, ?Context $parentContext = null): void
     {
     }
 

--- a/sdk/Trace/SpanProcessor/SimpleSpanProcessor.php
+++ b/sdk/Trace/SpanProcessor/SimpleSpanProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\Exporter;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Trace as API;
@@ -28,7 +29,7 @@ class SimpleSpanProcessor implements SpanProcessor
     /**
      * @inheritDoc
      */
-    public function onStart(API\Span $span): void
+    public function onStart(API\Span $span, ?Context $parentContext = null): void
     {
     }
 

--- a/sdk/Trace/SpanProcessor/SpanMultiProcessor.php
+++ b/sdk/Trace/SpanProcessor/SpanMultiProcessor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Sdk\Trace\SpanProcessor;
 
+use OpenTelemetry\Context\Context;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Trace as API;
 
@@ -31,10 +32,10 @@ final class SpanMultiProcessor implements SpanProcessor
         return $this->processors;
     }
 
-    public function onStart(API\Span $span): void
+    public function onStart(API\Span $span, ?Context $parentContext = null): void
     {
         foreach ($this->processors as $processor) {
-            $processor->onStart($span);
+            $processor->onStart($span, $parentContext);
         }
     }
 

--- a/sdk/Trace/TraceContext.php
+++ b/sdk/Trace/TraceContext.php
@@ -18,8 +18,8 @@ use OpenTelemetry\Trace as API;
  */
 final class TraceContext implements API\TextMapFormatPropagator
 {
-    public const TRACEPARENT = 'http_traceparent';
-    public const TRACESTATE = 'http_tracestate';
+    public const TRACEPARENT = 'traceparent';
+    public const TRACESTATE = 'tracestate';
     private const VERSION = '00'; // Currently only '00' is supported
     private const VALID_VERSION = '/^[0-9a-f]{2}$/';
     private const VALID_TRACEFLAGS = '/^[0-9a-f]{2}$/';

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -74,7 +74,7 @@ class Tracer implements API\Tracer
             $this->provider->getSpanProcessor()
         );
 
-        $this->provider->getSpanProcessor()->onStart($span);
+        $this->provider->getSpanProcessor()->onStart($span, $parentContext ?? Context::getCurrent());
 
         return $span;
     }

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -82,7 +82,7 @@ class Tracer implements API\Tracer
         if (SamplingResult::NOT_RECORD == $samplingResult->getDecision()) {
             $span = $this->generateSpanInstance('', $context);
         } else {
-            $span = $this->generateSpanInstance($name, $context, $sampler, $this->resource);
+            $span = $this->generateSpanInstance($name, $context, $sampler, $this->resource, $spanKind);
 
             if ($span->isRecording()) {
                 $this->provider->getSpanProcessor()->onStart($span);
@@ -186,7 +186,7 @@ class Tracer implements API\Tracer
         }
     }
 
-    private function generateSpanInstance(string $name, API\SpanContext $context, Sampler $sampler = null, ResourceInfo $resource = null): API\Span
+    private function generateSpanInstance(string $name, API\SpanContext $context, Sampler $sampler = null, ResourceInfo $resource = null, int $spanKind = API\SpanKind::KIND_INTERNAL): API\Span
     {
         $parent = null;
 
@@ -197,7 +197,7 @@ class Tracer implements API\Tracer
                 $parent = $this->getActiveSpan()->getContext();
             }
 
-            $span = new Span($name, $context, $parent, $sampler, $resource);
+            $span = new Span($name, $context, $parent, $sampler, $resource, $spanKind);
         }
         $this->spans[] = $span;
 

--- a/sdk/Trace/TracerProvider.php
+++ b/sdk/Trace/TracerProvider.php
@@ -60,7 +60,6 @@ final class TracerProvider implements API\TracerProvider
             return $this->tracers[$key];
         }
 
-        $spanContext = SpanContext::generateSampled();
         /*
          * A resource can be associated with the TracerProvider when the TracerProvider is created.
          * That association cannot be changed later. When associated with a TracerProvider, all
@@ -79,8 +78,7 @@ final class TracerProvider implements API\TracerProvider
 
         return $this->tracers[$key] = new Tracer(
             $this,
-            ResourceInfo::merge($primary, $resource),
-            $spanContext
+            ResourceInfo::merge($primary, $resource)
         );
     }
 

--- a/tests/Context/Unit/ContextValueTraitTest.php
+++ b/tests/Context/Unit/ContextValueTraitTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Context\Unit;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueTrait;
+use PHPUnit\Framework\TestCase;
+
+class ContextValueTraitTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function getContextKeyShouldBeCalledOnContextInteraction()
+    {
+        $ctxValue = new class() {
+            use ContextValueTrait;
+
+            private static $contextKey;
+
+            public static $invocations = 0; // spy counter
+
+            protected static function getContextKey(): ContextKey
+            {
+                self::$invocations++;
+
+                if (self::$contextKey === null) {
+                    self::$contextKey = new ContextKey('test-key');
+                }
+
+                return self::$contextKey;
+            }
+        };
+
+        $ctxValue::getCurrent();
+        $this->assertEquals(1, $ctxValue::$invocations);
+
+        $ctxValue::setCurrent($ctxValue);
+        $this->assertEquals(2, $ctxValue::$invocations);
+
+        $context = new Context();
+        $ctxValue::insert($ctxValue, $context);
+        $this->assertEquals(3, $ctxValue::$invocations);
+
+        $ctxValue::extract($context);
+        $this->assertEquals(4, $ctxValue::$invocations);
+    }
+}

--- a/tests/Context/Unit/ScopeTest.php
+++ b/tests/Context/Unit/ScopeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Context\Unit;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Context\ContextKey;
+use OpenTelemetry\Context\ContextValueNotFoundException;
+use OpenTelemetry\Context\Scope;
+use PHPUnit\Framework\TestCase;
+
+class ScopeTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function scopeCloseRestoresContext()
+    {
+        $key = new ContextKey();
+        $ctx = (new Context())->set($key, 'test');
+        $scope = new Scope(Context::attach($ctx));
+
+        $this->assertSame('test', Context::getValue($key));
+
+        $scope->close();
+
+        $this->expectException(ContextValueNotFoundException::class);
+        Context::getValue($key);
+    }
+
+    /**
+     * @test
+     */
+    public function testNestedScope()
+    {
+        $key = new ContextKey();
+        $ctx1 = (new Context())->set($key, 'test1');
+        $scope1 = new Scope(Context::attach($ctx1));
+        $this->assertSame('test1', Context::getValue($key));
+        
+        $ctx2 = (new Context())->set($key, 'test2');
+        $scope2 = new Scope(Context::attach($ctx2));
+        $this->assertSame('test2', Context::getValue($key));
+        
+        $scope2->close();
+        $this->assertSame('test1', Context::getValue($key));
+        
+        $scope1->close();
+        $this->expectException(ContextValueNotFoundException::class);
+        Context::getValue($key);
+    }
+}

--- a/tests/Contrib/Unit/NewrelicExporterTest.php
+++ b/tests/Contrib/Unit/NewrelicExporterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use OpenTelemetry\Contrib\Newrelic\Exporter;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+class NewrelicExporterTest extends TestCase
+{
+
+    /**
+     * @test
+     * @dataProvider exporterResponseStatusesDataProvider
+     */
+    public function exporterResponseStatuses($responseStatus, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willReturn(
+            new Response($responseStatus)
+        );
+
+        $exporter = new Exporter('test.newrelic', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.newrelic.span', SpanContext::generate())])
+        );
+    }
+
+    public function exporterResponseStatusesDataProvider()
+    {
+        return [
+            'ok'                => [200, Exporter::SUCCESS],
+            'not found'         => [404, Exporter::FAILED_NOT_RETRYABLE],
+            'not authorized'    => [401, Exporter::FAILED_NOT_RETRYABLE],
+            'bad request'       => [402, Exporter::FAILED_NOT_RETRYABLE],
+            'too many requests' => [429, Exporter::FAILED_NOT_RETRYABLE],
+            'server error'      => [500, Exporter::FAILED_RETRYABLE],
+            'timeout'           => [503, Exporter::FAILED_RETRYABLE],
+            'bad gateway'       => [502, Exporter::FAILED_RETRYABLE],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider clientExceptionsShouldDecideReturnCodeDataProvider
+     */
+    public function clientExceptionsShouldDecideReturnCode($exception, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException($exception);
+
+        $exporter = new Exporter('test.newrelic', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.newrelic.span', SpanContext::generate())])
+        );
+    }
+
+    public function clientExceptionsShouldDecideReturnCodeDataProvider()
+    {
+        return [
+            'client'    => [
+                self::createMock(ClientExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'network'   => [
+                self::createMock(NetworkExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'request'   => [
+                self::createMock(RequestExceptionInterface::class),
+                Exporter::FAILED_NOT_RETRYABLE,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeOkToExporterEmptySpansCollection()
+    {
+        $this->assertEquals(
+            Exporter::SUCCESS,
+            (new Exporter('test.newrelic', 'scheme://host:123/path', ''))->export([])
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDsnDataProvider
+     */
+    public function shouldThrowExceptionIfInvalidDsnIsPassed(string $invalidDsn)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Exporter('test.newrelic', $invalidDsn, '');
+    }
+
+    public function invalidDsnDataProvider()
+    {
+        return [
+            'missing scheme' => ['host/path'],
+            'missing host' => ['scheme://path'],
+            'missing path' => ['scheme://host'],
+            'invalid scheme' => ['1234://host:port/path'],
+            'invalid host' => ['scheme:///end:1234/path'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function failsIfNotRunning()
+    {
+        $exporter = new Exporter('test.newrelic', 'scheme://host/path', '');
+        $span = $this->createMock(Span::class);
+        $exporter->shutdown();
+
+        $this->assertEquals($exporter->export([$span]), \OpenTelemetry\Sdk\Trace\Exporter::FAILED_NOT_RETRYABLE);
+    }
+}

--- a/tests/Contrib/Unit/NewrelicSpanConverterTest.php
+++ b/tests/Contrib/Unit/NewrelicSpanConverterTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use OpenTelemetry\Contrib\Newrelic\SpanConverter;
+use OpenTelemetry\Sdk\Trace\Attribute;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+class NewrelicSpanConverterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldConvertASpanToAPayloadForNewrelic()
+    {
+        $tracer = (new TracerProvider())->getTracer('OpenTelemetry.NewrelicTest');
+
+        $timestamp = Clock::get()->timestamp();
+
+        /** @var Span $span */
+        $span = $tracer->startAndActivateSpan('guard.validate');
+        $span->setAttribute('service', 'guard');
+        $span->addEvent('validators.list', $timestamp, new Attributes(['job' => 'stage.updateTime']));
+        $span->end();
+
+        $converter = new SpanConverter('test.name');
+        $row = $converter->convert($span);
+
+        $this->assertSame($span->getContext()->getSpanId(), $row['id']);
+        $this->assertSame($span->getContext()->getTraceId(), $row['trace.id']);
+
+        $this->assertSame('test.name', $row['attributes']['service.name']);
+        $this->assertSame($span->getSpanName(), $row['attributes']['name']);
+        $this->assertNull($row['attributes']['parent.id']);
+        $this->assertSame($span->getSpanName(), $row['attributes']['name']);
+
+        $this->assertIsFloat($row['attributes']['timestamp']);
+        // timestamp should be in milliseconds
+        $this->assertGreaterThan(1e12, $row['attributes']['timestamp']);
+
+        $this->assertIsFloat($row['attributes']['duration.ms']);
+        $this->assertGreaterThan(0, $row['attributes']['duration.ms']);
+
+        /** @var Attribute $attribute */
+        $attribute = $span->getAttribute('service');
+        $this->assertEquals($attribute->getValue(), $row['attributes']['service']);
+    }
+
+    /**
+     * @test
+     */
+    public function durationShouldBeInMilliseconds()
+    {
+        $span = new Span('duration.test', SpanContext::generate());
+
+        $row = (new SpanConverter('duration.test'))->convert($span);
+
+        $this->assertEquals(
+            (($span->getEnd() - $span->getStart()) / 1000000),
+            $row['attributes']['duration.ms']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function attributesMaintainTypes()
+    {
+        $span = new Span('attributes.test', SpanContext::generate());
+
+        $listOfStrings = ['string-1','string-2'];
+        $listOfNumbers = [1,2,3,3.1415,42];
+        $listOfBooleans = [true,true,false,true];
+        $listOfRandoms = [true,[1,2,3],false,'string-1',3.1415];
+
+        $span->setAttribute('string', 'string');
+        $span->setAttribute('integer-1', 1024);
+        $span->setAttribute('integer-2', 0);
+        $span->setAttribute('float', '1.2345');
+        $span->setAttribute('boolean-1', true);
+        $span->setAttribute('boolean-2', false);
+        $span->setAttribute('list-of-strings', $listOfStrings);
+        $span->setAttribute('list-of-numbers', $listOfNumbers);
+        $span->setAttribute('list-of-booleans', $listOfBooleans);
+        $span->setAttribute('list-of-random', $listOfRandoms);
+
+        $attributes = (new SpanConverter('tags.test'))->convert($span)['attributes'];
+
+        // Check that we can convert all attributes to tags
+        $this->assertCount(17, $attributes);
+
+        // Attributes destined for Newrelic must be key/value pairs
+
+        $this->assertEquals($attributes['string'], 'string');
+        $this->assertEquals($attributes['integer-1'], 1024);
+        $this->assertEquals($attributes['integer-2'], 0);
+        $this->assertEquals($attributes['float'], 1.2345);
+        $this->assertEquals($attributes['boolean-1'], true);
+        $this->assertEquals($attributes['boolean-2'], false);
+
+        // Lists are accepted
+        $this->assertEquals($attributes['list-of-strings'], $listOfStrings);
+        $this->assertEquals($attributes['list-of-numbers'], $listOfNumbers);
+        $this->assertEquals($attributes['list-of-booleans'], $listOfBooleans);
+
+        // This currently works, but OpenTelemetry\Trace\Span should stop arrays
+        // containing multiple value types from being passed to the Exporter.
+        $this->assertEquals($attributes['list-of-random'], $listOfRandoms);
+    }
+}

--- a/tests/Contrib/Unit/ZipkinToNewrelicExporterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNewrelicExporterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use OpenTelemetry\Contrib\ZipkinToNewrelic\Exporter;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
+use Psr\Http\Client\RequestExceptionInterface;
+
+class ZipkinToNewrelicExporterTest extends TestCase
+{
+
+    /**
+     * @test
+     * @dataProvider exporterResponseStatusesDataProvider
+     */
+    public function exporterResponseStatuses($responseStatus, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willReturn(
+            new Response($responseStatus)
+        );
+
+        $exporter = new Exporter('test.zipkinToNR', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.zipkin.span', SpanContext::generate())])
+        );
+    }
+
+    public function exporterResponseStatusesDataProvider()
+    {
+        return [
+            'ok'                => [200, Exporter::SUCCESS],
+            'not found'         => [404, Exporter::FAILED_NOT_RETRYABLE],
+            'not authorized'    => [401, Exporter::FAILED_NOT_RETRYABLE],
+            'bad request'       => [402, Exporter::FAILED_NOT_RETRYABLE],
+            'too many requests' => [429, Exporter::FAILED_NOT_RETRYABLE],
+            'server error'      => [500, Exporter::FAILED_RETRYABLE],
+            'timeout'           => [503, Exporter::FAILED_RETRYABLE],
+            'bad gateway'       => [502, Exporter::FAILED_RETRYABLE],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider clientExceptionsShouldDecideReturnCodeDataProvider
+     */
+    public function clientExceptionsShouldDecideReturnCode($exception, $expected)
+    {
+        $client = self::createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException($exception);
+
+        $exporter = new Exporter('test.zipkinToNR', 'scheme://host:123/path', '', null, $client);
+
+        $this->assertEquals(
+            $expected,
+            $exporter->export([new Span('test.zipkinToNR.span', SpanContext::generate())])
+        );
+    }
+
+    public function clientExceptionsShouldDecideReturnCodeDataProvider()
+    {
+        return [
+            'client'    => [
+                self::createMock(ClientExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'network'   => [
+                self::createMock(NetworkExceptionInterface::class),
+                Exporter::FAILED_RETRYABLE,
+            ],
+            'request'   => [
+                self::createMock(RequestExceptionInterface::class),
+                Exporter::FAILED_NOT_RETRYABLE,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeOkToExporterEmptySpansCollection()
+    {
+        $this->assertEquals(
+            Exporter::SUCCESS,
+            (new Exporter('test.zipkinToNR', 'scheme://host:123/path', ''))->export([])
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDsnDataProvider
+     */
+    public function shouldThrowExceptionIfInvalidDsnIsPassed(string $invalidDsn)
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Exporter('test.zipkinToNR', $invalidDsn, '');
+    }
+
+    public function invalidDsnDataProvider()
+    {
+        return [
+            'missing scheme' => ['host/path'],
+            'missing host' => ['scheme://path'],
+            'missing path' => ['scheme://host'],
+            'invalid scheme' => ['1234://host:port/path'],
+            'invalid host' => ['scheme:///end:1234/path'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function failsIfNotRunning()
+    {
+        $exporter = new Exporter('test.zipkinToNr', 'scheme://host/path', '');
+        $span = $this->createMock(Span::class);
+        $exporter->shutdown();
+
+        $this->assertEquals($exporter->export([$span]), \OpenTelemetry\Sdk\Trace\Exporter::FAILED_NOT_RETRYABLE);
+    }
+}

--- a/tests/Contrib/Unit/ZipkinToNrSpanConverterTest.php
+++ b/tests/Contrib/Unit/ZipkinToNrSpanConverterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Contrib\Unit;
+
+use OpenTelemetry\Contrib\ZipkinToNewrelic\SpanConverter;
+use OpenTelemetry\Sdk\Trace\Attribute;
+use OpenTelemetry\Sdk\Trace\Attributes;
+use OpenTelemetry\Sdk\Trace\Clock;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use PHPUnit\Framework\TestCase;
+
+class ZipkinToNewrelicSpanConverterTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function shouldConvertASpanToAPayloadForZipkin()
+    {
+        $tracer = (new TracerProvider())->getTracer('OpenTelemetry.ZipkinToNewrelicTest');
+
+        $timestamp = Clock::get()->timestamp();
+
+        /** @var Span $span */
+        $span = $tracer->startAndActivateSpan('guard.validate');
+        $span->setAttribute('service', 'guard');
+        $span->addEvent('validators.list', $timestamp, new Attributes(['job' => 'stage.updateTime']));
+        $span->end();
+
+        $converter = new SpanConverter('test.name');
+        $row = $converter->convert($span);
+
+        $this->assertSame($span->getContext()->getSpanId(), $row['id']);
+        $this->assertSame($span->getContext()->getTraceId(), $row['traceId']);
+
+        $this->assertSame('test.name', $row['localEndpoint']['serviceName']);
+        $this->assertSame($span->getSpanName(), $row['name']);
+
+        $this->assertIsInt($row['timestamp']);
+        // timestamp should be in microseconds
+        $this->assertGreaterThan(1e15, $row['timestamp']);
+
+        $this->assertIsInt($row['duration']);
+        $this->assertGreaterThan(0, $row['duration']);
+
+        $this->assertCount(3, $row['tags']);
+
+        /** @var Attribute $attribute */
+        $attribute = $span->getAttribute('service');
+        $this->assertEquals($attribute->getValue(), $row['tags']['service']);
+
+        $this->assertCount(1, $row['annotations']);
+        [$annotation] = $row['annotations'];
+        $this->assertEquals('validators.list', $annotation['value']);
+
+        [$event] = \iterator_to_array($span->getEvents());
+        $this->assertIsInt($annotation['timestamp']);
+
+        // timestamp should be in microseconds
+        $this->assertGreaterThan(1e15, $annotation['timestamp']);
+    }
+
+    /**
+     * @test
+     */
+    public function durationShouldBeInMicroseconds()
+    {
+        $span = new Span('duration.test', SpanContext::generate());
+
+        $row = (new SpanConverter('duration.test'))->convert($span);
+
+        $this->assertEquals(
+            (int) (($span->getEnd() - $span->getStart()) / 1000),
+            $row['duration']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function tagsAreCoercedCorrectlyToStrings()
+    {
+        $span = new Span('tags.test', SpanContext::generate());
+
+        $listOfStrings = ['string-1','string-2'];
+        $listOfNumbers = [1,2,3,3.1415,42];
+        $listOfBooleans = [true,true,false,true];
+        $listOfRandoms = [true,[1,2,3],false,'string-1',3.1415];
+
+        $span->setAttribute('string', 'string');
+        $span->setAttribute('integer-1', 1024);
+        $span->setAttribute('integer-2', 0);
+        $span->setAttribute('float', '1.2345');
+        $span->setAttribute('boolean-1', true);
+        $span->setAttribute('boolean-2', false);
+        $span->setAttribute('list-of-strings', $listOfStrings);
+        $span->setAttribute('list-of-numbers', $listOfNumbers);
+        $span->setAttribute('list-of-booleans', $listOfBooleans);
+        $span->setAttribute('list-of-random', $listOfRandoms);
+
+        $tags = (new SpanConverter('tags.test'))->convert($span)['tags'];
+
+        // Check that we can convert all attributes to tags
+        $this->assertCount(12, $tags);
+
+        // Tags destined for Zipkin must be pairs of strings
+        foreach ($tags as $tagKey => $tagValue) {
+            $this->assertIsString($tagKey);
+            $this->assertIsString($tagValue);
+        }
+
+        $this->assertEquals($tags['string'], 'string');
+        $this->assertEquals($tags['integer-1'], '1024');
+        $this->assertEquals($tags['integer-2'], '0');
+        $this->assertEquals($tags['float'], '1.2345');
+        $this->assertEquals($tags['boolean-1'], 'true');
+        $this->assertEquals($tags['boolean-2'], 'false');
+
+        // Lists must be casted to strings and joined with a separator
+        $this->assertEquals($tags['list-of-strings'], join(',', $listOfStrings));
+        $this->assertEquals($tags['list-of-numbers'], join(',', $listOfNumbers));
+        $this->assertEquals($tags['list-of-booleans'], 'true,true,false,true');
+
+        // This currently works, but OpenTelemetry\Trace\Span should stop arrays
+        // containing multiple value types from being passed to the Exporter.
+        $this->assertEquals($tags['list-of-random'], 'true,1,2,3,false,string-1,3.1415');
+    }
+}

--- a/tests/Sdk/Integration/SpanProcessorTest.php
+++ b/tests/Sdk/Integration/SpanProcessorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenTelemetry\Tests\Sdk\Integration;
+
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\SpanProcessor;
+use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace\Span;
+use PHPUnit\Framework\TestCase;
+
+class SpanProcessorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function parentContextShouldBePassedToSpanProcessor()
+    {
+        $parentContext = new Context();
+
+        $spanProcessor = $this->createMock(SpanProcessor::class);
+        $spanProcessor
+            ->expects($this->once())
+            ->method('onStart')
+            ->with($this->isInstanceOf(Span::class), $this->equalTo($parentContext))
+        ;
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($spanProcessor);
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.Test');
+        $tracer->startSpan('test.span', $parentContext);
+    }
+
+    /**
+     * @test
+     */
+    public function currentContextShouldBePassedToSpanProcessorByDefault()
+    {
+        $currentContext = Context::getCurrent();
+
+        $spanProcessor = $this->createMock(SpanProcessor::class);
+        $spanProcessor
+            ->expects($this->once())
+            ->method('onStart')
+            ->with($this->isInstanceOf(Span::class), $this->equalTo($currentContext))
+        ;
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($spanProcessor);
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.Test');
+        $tracer->startSpan('test.span', null);
+    }
+}

--- a/tests/Sdk/Unit/Trace/PropagationMapTest.php
+++ b/tests/Sdk/Unit/Trace/PropagationMapTest.php
@@ -110,4 +110,19 @@ class PropagationMapTest extends TestCase
         $this->expectExceptionMessage('Unable to set value with an empty key');
         $map->set($carrier, '', 'alpha');
     }
+
+    /**
+     * @test
+     */
+    public function testGetArrayValuesFromCarrier()
+    {
+        // Carrier contains an array as one of the values
+        $carrier = [
+            'a' => 'alpha',
+            'b' => ['bravo'],
+        ];
+        $map = new PropagationMap();
+        $this->assertSame('alpha', $map->get($carrier, 'a'));
+        $this->assertSame('bravo', $map->get($carrier, 'b'));
+    }
 }

--- a/tests/Sdk/Unit/Trace/TracerTest.php
+++ b/tests/Sdk/Unit/Trace/TracerTest.php
@@ -4,12 +4,112 @@ declare(strict_types=1);
 
 namespace OpenTelemetry\Tests\Sdk\Unit\Trace;
 
+use OpenTelemetry\Context\Context;
+use OpenTelemetry\Sdk\Trace\NoopSpan;
+use OpenTelemetry\Sdk\Trace\Span;
+use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanProcessor;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
 use PHPUnit\Framework\TestCase;
 
 class TracerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Context::attach(new Context()); // clean up the current Context
+    }
+
+    /**
+     * @test
+     */
+    public function spanProcessorsShouldBeCalledWhenNewSpanIsStarted()
+    {
+        $processor = self::createMock(SpanProcessor::class);
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($processor);
+
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+
+        $processor->expects($this->exactly(1))->method('onStart')->with($this->isInstanceOf(Span::class));
+        $tracer->startSpan('test.span');
+    }
+
+    /**
+     * @test
+     */
+    public function spanProcessorsShouldBeCalledWhenSpanEnded()
+    {
+        $processor = self::createMock(SpanProcessor::class);
+
+        $tracerProvider = new TracerProvider();
+        $tracerProvider->addSpanProcessor($processor);
+
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span = $tracer->startSpan('test.span');
+
+        $processor->expects($this->exactly(1))->method('onEnd')->with($this->equalTo($span));
+        $span->end();
+    }
+
+    /**
+     * @test
+     */
+    public function activeSpanFromCurrentContextShouldBeUsedAsParent()
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span1 = $tracer->startSpan('test.span.1');
+        Span::setCurrent($span1);
+        $span2 = $tracer->startSpan('test.span.2');
+
+        $this->assertEquals($span1->getContext()->getTraceId(), $span2->getContext()->getTraceId());
+        $this->assertNotEquals($span1->getContext()->getSpanId(), $span2->getContext()->getSpanId());
+
+        $span2ParentContext = $span2->getParent();
+        $this->assertNotNull($span2ParentContext);
+        $this->assertEquals($span1->getContext()->getSpanId(), $span2ParentContext->getSpanId());
+    }
+
+    /**
+     * @test
+     */
+    public function spanAndParentContextShouldHaveIdenticalTraceId()
+    {
+        $parentSpan = new NoopSpan(new SpanContext(
+            'faa0c74e14bd78114ec2bc447ad94ec9',
+            '50a75f197c3de59a',
+            SpanContext::TRACE_FLAG_SAMPLED
+        ));
+        $parentContext = (new Context());
+        $parentContext = Span::insert($parentSpan, $parentContext);
+
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $childSpan = $tracer->startSpan('test.span', $parentContext);
+
+        $this->assertEquals($parentSpan->getContext()->getTraceId(), $childSpan->getContext()->getTraceId());
+        $this->assertNotEquals($parentSpan->getContext()->getSpanId(), $childSpan->getContext()->getSpanId());
+
+        $parentSpanContext = $childSpan->getParent();
+        $this->assertNotNull($parentSpanContext);
+        $this->assertEquals($parentSpan->getContext()->getSpanId(), $parentSpanContext->getSpanId());
+    }
+
+    /**
+     * @test
+     */
+    public function rootSpansShouldHaveDifferentTraceId()
+    {
+        $tracerProvider = new TracerProvider();
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracerTest');
+        $span1 = $tracer->startSpan('test.span.1');
+        $span2 = $tracer->startSpan('test.span.2');
+
+        $this->assertNotEquals($span1->getContext()->getTraceId(), $span2->getContext()->getTraceId());
+    }
+
     /**
      * @test
      */

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -17,6 +17,7 @@ use OpenTelemetry\Sdk\Trace\SpanContext;
 use OpenTelemetry\Sdk\Trace\SpanStatus;
 use OpenTelemetry\Sdk\Trace\Tracer;
 use OpenTelemetry\Sdk\Trace\TracerProvider;
+use OpenTelemetry\Trace as API;
 use PHPUnit\Framework\TestCase;
 
 class TracingTest extends TestCase
@@ -143,6 +144,32 @@ class TracingTest extends TestCase
 
         // active span rolled back
         $this->assertSame($tracer->getActiveSpan(), $global);
+    }
+
+    public function testCreateSpanWithSpanKind()
+    {
+        $tracerProvider = new SDK\TracerProvider(null, new SDK\Sampler\AlwaysOnSampler());
+        $tracer = $tracerProvider->getTracer('OpenTelemetry.TracingTest');
+
+        $span = $tracer->startAndActivateSpan('someSpan');
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_INTERNAL);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_CLIENT);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_CLIENT);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_SERVER);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_SERVER);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_PRODUCER);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_PRODUCER);
+        $span->end();
+
+        $span = $tracer->startAndActivateSpan('someSpan', API\SpanKind::KIND_CONSUMER);
+        $this->assertSame($span->getSpanKind(), API\SpanKind::KIND_CONSUMER);
+        $span->end();
     }
 
     public function testGetStatus()


### PR DESCRIPTION
Updated the automated Docker environment to take advantage of your exporter.

If the metadata [portion](https://github.com/open-telemetry/opentelemetry-php/pull/272/files#diff-cf404624c6256e3fc83bafddf4c0c555d4b7f84f8803c485c8ba224f2d09d75bR106) is commented out,  
run `make collector-trace` and it will send the traces to whatever endpoint the collector is configured for.

The collector endpoint url is set either with an environment variable (`OTEL_EXPORTER_OTLP_ENDPOINT`) prior to running `make collector-trace`, or it's set in the `AlwaysOnOTLPGrpcExample.php` when passing the [url](https://github.com/open-telemetry/opentelemetry-php/pull/272/files#diff-01afdce2a161ec82515a77e940600253fc4f9351c7dcae7ba9a7055c5f47a46eR24) to the exporter.